### PR TITLE
Add pytest test for JSON control counts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 streamlit
 pandas
+pytest

--- a/tests/test_controls_json.py
+++ b/tests/test_controls_json.py
@@ -1,0 +1,10 @@
+import json
+import os
+
+
+def test_each_domain_has_seven_controls():
+    json_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "qsaf_controls_all_domains.json")
+    with open(json_path, "r") as f:
+        data = json.load(f)
+    for domain, controls in data.items():
+        assert len(controls) == 7, f"{domain} expected 7 controls, got {len(controls)}"


### PR DESCRIPTION
## Summary
- add pytest to requirements
- test that each domain in the JSON controls file contains seven entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855e148db8c832abaccbfa43d68c726