### PR TITLE
Fix duplicate control IDs

### DIFF
--- a/qsaf_controls_all_domains.json
+++ b/qsaf_controls_all_domains.json
@@ -151,31 +151,31 @@
   ],
   "Domain 6: Payload Integrity & Signing": [
     [
-      "QSAF-PI-001",
+      "QSAF-IS-001",
       "Prompt hash signing"
     ],
     [
-      "QSAF-PI-002",
+      "QSAF-IS-002",
       "Response payload signing"
     ],
     [
-      "QSAF-PI-003",
+      "QSAF-IS-003",
       "Plugin request signature enforcement"
     ],
     [
-      "QSAF-PI-004",
+      "QSAF-IS-004",
       "Signature verification middleware"
     ],
     [
-      "QSAF-PI-005",
+      "QSAF-IS-005",
       "Nonce/replay token control"
     ],
     [
-      "QSAF-PI-006",
+      "QSAF-IS-006",
       "Hash chain lineage"
     ],
     [
-      "QSAF-PI-007",
+      "QSAF-IS-007",
       "Invalid signature escalation"
     ]
   ],


### PR DESCRIPTION
## Summary
- fix duplicate IDs in the payload integrity controls

## Testing
- `python3 -m py_compile qsaf_streamlit_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6855d8a29e34832aa31aef2c6b487b30